### PR TITLE
Add pkgconfig dependency for SDL2

### DIFF
--- a/SDL2-ttf.cabal
+++ b/SDL2-ttf.cabal
@@ -22,6 +22,7 @@ Library
   include-dirs:     cbits
   C-sources:        cbits/rendering.c
   extra-libraries:  SDL2, SDL2_ttf
+  pkgconfig-depends: sdl2
 
 source-repository head
     type:     git


### PR DESCRIPTION
This is needed for distributions like nixos, or in scenarios where you chose a different --prefix for SDL2 and SDL2_ttf. I've tested this on my machine and it works.